### PR TITLE
Update load_argos.R

### DIFF
--- a/load_argos.R
+++ b/load_argos.R
@@ -41,7 +41,7 @@ load_argos<-function(odir) {
 
     dpt=read_tsv(file.path(pdir,"data_clinical_patient.txt"),comment="#")
 
-    maf=read_tsv(fs::dir_ls(adir,regex=".muts.maf$"),comment="#")
+    maf=read_tsv(fs::dir_ls(adir,regex=".muts.maf$"),comment="#",col_types = cols(.default = "?", Chromosome = "character"))
 
     pairingTable=maf %>%
         distinct(SAMPLE_ID=Tumor_Sample_Barcode,NORMAL_ID=Matched_Norm_Sample_Barcode) %>%


### PR DESCRIPTION
by default chromosome col is read as numeric, but in other tables it is character, resulting an error like below

for this project: /juno/res/ci/voyager/argos/./13792/1.1.2/20221123_16_45_510150

for this sample:  s_C_PAE3NL_P002_d02


Quitting from lines 20-22 (report_sample_level.Rmd)                             
  10536 Error in `left_join()`:                                                         
  10537 ! Can't join on `x$Chromosome` x `y$Chromosome` because of incompatible         
  10538   types.                                                                        
  10539 ℹ `x$Chromosome` is of type <double>>.                                          
  10540 ℹ `y$Chromosome` is of type <character>>.                                       
  10541 Backtrace:                                                                      
  10542  1. global load_data(params$argosDir, params$sampleID)                          
  10543  5. dplyr:::left_join.data.frame(., oncoKb$dat, by = oncoKbKey)