### PR TITLE
Bug fixes and No CNV for unmatched

### DIFF
--- a/load_argos.R
+++ b/load_argos.R
@@ -46,7 +46,7 @@ load_argos<-function(inputs) {
     pdir=inputs$portal_dir
     adir=inputs$analysis_dir
 
-    dpt=read_tsv(file.path(pdir,"data_clinical_patient.txt"),comment="#")
+    dpt=read_tsv(file.path(pdir,"data_clinical_patient.txt"),comment="#",col_types = cols(.default = "?", SEX = "character"),show_col_types = TRUE)
 
     maf=read_tsv(fs::dir_ls(adir,regex=".muts.maf$"),comment="#",col_types = cols(.default = "?", Chromosome = "character"))
 

--- a/load_data.R
+++ b/load_data.R
@@ -33,10 +33,6 @@ load_data<-function(sample_id,inputs) {
     mafTbl=res$mafTbl
     mafTblFull=res$mafTblFull
 
-    cnvTbl=get_cnv_table(argos_data,sample_id)
-
-    cnvTblFull=get_cnv_table_full(argos_data,sample_id)
-
     fusionTbl=get_fusion_table(argos_data,sample_id)
 
     nMut=number_of_events(mafTbl)
@@ -45,13 +41,17 @@ load_data<-function(sample_id,inputs) {
     nMutFull=number_of_events(mafTblFull)
     
 
-    summaryTxt=glue("Number of mutations: {nMut}; high level copy number alterations: {nCNV}; structural variants: {nFusion}")
+    
 
     if(!isUnMatched) {
         
+        cnvTbl=get_cnv_table(argos_data,sample_id)
+        cnvTblFull=get_cnv_table_full(argos_data,sample_id)
         nCNV=number_of_events(cnvTbl)
         nCNVFull=number_of_events(cnvTblFull)
 
+        summaryTxt=glue("Number of mutations: {nMut}; high level copy number alterations: {nCNV}; structural variants: {nFusion}")
+        
         if(! is.null(argos_data[[sample_id]]$MSI_STATUS)){
             msiTxt=glue("MSI Status = {MSI_STATUS}, score = {MSI_SCORE}",.envir=argos_data[[sample_id]])
         }
@@ -77,6 +77,8 @@ load_data<-function(sample_id,inputs) {
         source("create_tables.R")
         cnvTbl=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
         cnvTblFull=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
+        
+        summaryTxt=glue("Number of mutations: {nMut}; structural variants: {nFusion}")
         
         summaryTbl=tribble(
             ~Section, ~Data,

--- a/load_data.R
+++ b/load_data.R
@@ -64,8 +64,8 @@ load_data<-function(sample_id,inputs) {
         }
         summaryTbl=tribble(
             ~Section, ~Data,
-          # "Summary:", summaryTxt, ## MSI temporarly turned off, until we make sure its accuracy
-            "MSI Status:", msiTxt,
+           "Summary:", summaryTxt,
+          #  "MSI Status:", msiTxt,## MSI temporarly turned off, until we make sure its accuracy
             "TMB Value:", tmbTxt
         )
 

--- a/load_data.R
+++ b/load_data.R
@@ -36,6 +36,12 @@ load_data<-function(sample_id,inputs) {
     fusionTbl=get_fusion_table(argos_data,sample_id)
 
     nMut=number_of_events(mafTbl)
+    
+    if(nMut==0) {
+        cat("\n\nFATAL ERROR: zero mutation sample",sample_id,"\n")
+        cat("No mutation samples can not be identified as Matched or UnMatched, needs manual run\n\n\n")
+        rlang::abort("FATAL ERROR")
+    }
 
     nFusion=number_of_events(fusionTbl)
     nMutFull=number_of_events(mafTblFull)

--- a/load_data.R
+++ b/load_data.R
@@ -21,7 +21,7 @@ load_data<-function(sample_id,inputs) {
     if(is.null(argos_data[[sample_id]])) {
         cat("\n\nFATAL ERROR: invalid sample",sample_id,"\n")
         cat("argos_dir =",argos_dir,"\n\n\n")
-        rlang::abort("FATAL ERROR")
+        rlang::abort("FATAL ERROR: invalid sample")
     }
 
     isUnMatched=argos_data[[sample_id]]$MATCH == "UnMatched"
@@ -36,28 +36,28 @@ load_data<-function(sample_id,inputs) {
     fusionTbl=get_fusion_table(argos_data,sample_id)
 
     nMut=number_of_events(mafTbl)
-    
+
     if(nMut==0) {
         cat("\n\nFATAL ERROR: zero mutation sample",sample_id,"\n")
         cat("No mutation samples can not be identified as Matched or UnMatched, needs manual run\n\n\n")
-        rlang::abort("FATAL ERROR")
+        rlang::abort("FATAL ERROR: zero mutation sample")
     }
 
     nFusion=number_of_events(fusionTbl)
     nMutFull=number_of_events(mafTblFull)
-    
 
-    
+
+
 
     if(!isUnMatched) {
-        
+
         cnvTbl=get_cnv_table(argos_data,sample_id)
         cnvTblFull=get_cnv_table_full(argos_data,sample_id)
         nCNV=number_of_events(cnvTbl)
         nCNVFull=number_of_events(cnvTblFull)
 
         summaryTxt=glue("Number of mutations: {nMut}; high level copy number alterations: {nCNV}; structural variants: {nFusion}")
-        
+
         if(! is.null(argos_data[[sample_id]]$MSI_STATUS)){
             msiTxt=glue("MSI Status = {MSI_STATUS}, score = {MSI_SCORE}",.envir=argos_data[[sample_id]])
         }
@@ -83,9 +83,9 @@ load_data<-function(sample_id,inputs) {
         source("create_tables.R")
         cnvTbl=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
         cnvTblFull=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
-        
+
         summaryTxt=glue("Number of mutations: {nMut}; structural variants: {nFusion}")
-        
+
         summaryTbl=tribble(
             ~Section, ~Data,
             "Summary:", summaryTxt,

--- a/load_data.R
+++ b/load_data.R
@@ -40,14 +40,17 @@ load_data<-function(sample_id,inputs) {
     fusionTbl=get_fusion_table(argos_data,sample_id)
 
     nMut=number_of_events(mafTbl)
-    nCNV=number_of_events(cnvTbl)
+
     nFusion=number_of_events(fusionTbl)
     nMutFull=number_of_events(mafTblFull)
-    nCNVFull=number_of_events(cnvTblFull)
+    
 
     summaryTxt=glue("Number of mutations: {nMut}; high level copy number alterations: {nCNV}; structural variants: {nFusion}")
 
     if(!isUnMatched) {
+        
+        nCNV=number_of_events(cnvTbl)
+        nCNVFull=number_of_events(cnvTblFull)
 
         if(! is.null(argos_data[[sample_id]]$MSI_STATUS)){
             msiTxt=glue("MSI Status = {MSI_STATUS}, score = {MSI_SCORE}",.envir=argos_data[[sample_id]])
@@ -71,10 +74,14 @@ load_data<-function(sample_id,inputs) {
 
     } else {
 
+        source("create_tables.R")
+        cnvTbl=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
+        cnvTblFull=get_null_table("The copy number for the tumor samples with unmatched pooled normals are unreliable and should be ignored.")
+        
         summaryTbl=tribble(
             ~Section, ~Data,
             "Summary:", summaryTxt,
-            "Comments:", "This sample was run un-matched (against a pooled normal) so the ExAC Germline Filter was applied"
+            "Comments:", "This sample was run un-matched (against a pooled normal) so the ExAC Germline Filter was applied and copy number alterations are not reported."
         )
 
     }


### PR DESCRIPTION
These points have been addressed:
- No mutation (after filtering) samples were not been able to successfully identified as matched or unmatched, so for now those samples will cause a Fatal Error and will be run manually, until we fix this issue.
- UnMatched samples' CNV is no longer being reported
- if SEX column was all Females (Fs) R assumes this column to be logical values, so needed to say column type explicitly
-fixed, temporarily hiding MSI, commented out the wrong line
-updated Fatal Error messages
